### PR TITLE
Descrição do comando .node adicionada.

### DIFF
--- a/bot/pt-BR/help.json
+++ b/bot/pt-BR/help.json
@@ -43,6 +43,10 @@
         "desc": "Executar várias funções relacionadas ao sistema de moderadores."
     },
 
+    "node": {
+        "desc": "Altera a versão do node para v14."
+    },
+
     "novoup": {
         "desc": "Upar um bot usando o ficheiro de configuração .discloudconfig"
     },


### PR DESCRIPTION
Eu vi que quando usa o comando .help, não aparece a descrição do comando .node e então decidi fazer esse ajuste.