### PR TITLE
🇧🇷 Simples erros em: emails.json

### DIFF
--- a/V2/bot/locales/pt-BR/emails.json
+++ b/V2/bot/locales/pt-BR/emails.json
@@ -5,7 +5,7 @@
         },
 
         "footer": {
-            "texto": "Obrigado pelo interesse em nossos serviços, continuamos disponíveis para qualquer informação adicional, sinta-se á vontade para nos contatar se tiver alguma pergunta ou comentário.",
+            "texto": "Obrigado pelo interesse nos nossos serviços, continuamos disponíveis para qualquer informação adicional, sinta-se à vontade para nos contatar se tiver alguma pergunta ou comentário.",
             "atenciosamente": "Atenciosamente,",
             "discloud_team": "Equipe DisCloud"
         }
@@ -14,15 +14,15 @@
     "daysleft": {
         "subject_1": "Renovação do seu plano {{PLAN}} (1 dia restando)",
         "subject_3": "Renovação do seu plano {{PLAN}} (3 dias restando)",
-        "texto_1": "O seu plano <b>{{PLAN}}</b> expirará em <b>{{REST}}</b>. Você pode renovar o seu plano clicando no botão abaixo. Lembre-se de fazer um backups das suas aplicações!",
+        "texto_1": "O seu plano <b>{{PLAN}}</b> expirará em <b>{{REST}}</b>. Você pode renovar o mesmo clicando no botão abaixo. Lembre-se de fazer o backup das suas aplicações!",
         "texto_2": "No final do prazo todos os dados das suas aplicações e instâncias serão excluídos permanentemente.",
         "renew_plan": "Renovar plano"
     },
 
     "backupbots": {
         "subject": "Backup das suas aplicações.",
-        "texto_1": "Os suas aplicações foram removidos pois o seu plano <b>{{PLAN}}</b> terminou. Você pode realizar o download do backups das suas aplicações clicando no botões abaixo. Lembre-se que suas aplicações podem voltar a ficar online com o nosso plano <b>Free</b> ou pode comprar um novo plano <b><a href='https://discloudbot.com/#precos'>clicando aqui</a></b>.",
-        "texto_2": "Você tem 1 mês para fazer o download dos backups das suas aplicações, caso contrário, os mesmos serão eliminados permanentemente.",
+        "texto_1": "As suas aplicações foram removidas, pois, o seu plano <b>{{PLAN}}</b> terminou. Você pode realizar o download do backup das suas aplicações clicando nos botões abaixo. Lembre-se que as suas aplicações podem voltar a ficar online com o nosso plano <b>Free</b> ou pode comprar um novo plano <b><a href='https://discloudbot.com/#precos'>clicando aqui</a></b>.",
+        "texto_2": "Você tem 1 mês para fazer o download do backup das suas aplicações, caso contrário, serão eliminados permanentemente.",
         "download_bot": "Download {{BOTNAME}} backup"
     }
 }


### PR DESCRIPTION
- Em muitos dos casos tinha "`o backups`" por exemplo, porém, quando nestes casos se está referindo a "`backups`", também está se referindo às aplicações, logo, o backup é das aplicações o que torna mais correto, "`o backup das aplicações`"
- Falta de vírgulas em "`texto_1`"
- Erro de acento em "`footer`" > "`texto`"
- Sbustituição de "`seu plano`" por "`o mesmo`" em "`daysleft`" > "`texto_1`" para não ficar sempre repetindo "plano" `(algo mais banal mas que faz uma certa diferença para não ficar sempre repetindo a mesma coisa em um curto espaço de tempo)`