### PR TITLE
Mudança do sentido da frase ao fazer backup

### DIFF
--- a/V2/bot/locales/pt-BR/commands.json
+++ b/V2/bot/locales/pt-BR/commands.json
@@ -138,7 +138,7 @@
       "delay": "Você tem que esperar mais `{{minutes}}m e {{seconds}}s` para poder fazer um novo backup.",
       "cancel": "A ação foi cancelada.",
       "erro": "**Ocorreu um erro ao tentar gerar o backup da sua aplicação.**",
-      "backup": "O backup do arquivo/pasta da ua aplicação foi enviado no seu DM.",
+      "backup": "O backup do arquivo/pasta foi gerado e enviado.",
       "embedDesc": {
         "diretorio": "Diretório:",
         "tamanho": "Tamanho:",


### PR DESCRIPTION
Ao usar `,dir` e selecionar a opção para realizar as maniupulações em DM, uma das frases estava dizendo que as informações do Backup foram enviadas na DM sendo que o usuário já estava na DM, então simplesmente foi mudado o sentido da frase para não citar DM e ao mesmo tempo ser objetivo com a sua devida ação feita.